### PR TITLE
Fix deprecated `pkg_resources`. Update command `m3 mreport --help`. Fixed setup config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.101.2] - 2023-12-01
+* Update command `m3 mreport --help`:
+  * Disable validation for the `region` parameter
+  * Update help text for the `region` parameter
+
+## [3.101.1] - 2023-11-28
+* Fix deprecated `pkg_resources`
+
 ## [3.101.0] - 2023-11-22
 * Add `--tenant-group` parameter to `multitenant-report`
 * Add `ANNUAL` option to `--report-type` parameter to `multitenant-report`

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ automate them through scripts.
 
 # Synopsis
 
-`m3-cli <command> [parameters]`
+`m3 <command> [parameters]`
 
-Use m3-cli command help for information on a specific command. The synopsis for each
+Use m3 command help for information on a specific command. The synopsis for each
 command shows its parameters and their usage. Required parameters are marked
 with the star (*) character.
 
@@ -55,14 +55,14 @@ Create: `virtualenv -p python3 .venv`
 
 Activate: `source .venv/bin/activate`
 
-### To install m3cli tool use the command listed below installation command.
+### To install m3-cli tool use the command listed below installation command.
 
 ##### ![#f03c15](pics/0000.png) NOTE: Replace tool version with the version number you need (see `CHANGELOG.md` or `setup.py`).
 
 `pip install m3-cli`
 ## Configuration
 
-Before using m3 cli execute commnad `m3-cli access` to set up all needed settings.
+Before using m3 cli execute commnad `m3 access` to set up all needed settings.
 
 In case you want to configure all needed settings manually, please set up the
 following environmnet variables:
@@ -72,11 +72,11 @@ following environmnet variables:
   This is essentially the "password" for the access key.
 * `M3SDK_ADDRESS`: Specifies the address of the Maestro3 environment.
 
-Or you can set credentials non-interactively using `m3-cli access` command with
+Or you can set credentials non-interactively using `m3 access` command with
 specified parameters:
 
 ```
-m3-cli access --access_key <access_key> --secret_key <_secret_key> --api_address <api_address>
+m3 access --access_key <access_key> --secret_key <_secret_key> --api_address <api_address>
 ```
 
 After this a `default.cr` file with the access parameters you provided will be 
@@ -125,7 +125,7 @@ variables, the m3 cli is ready to be used.
 
 ##### ![#f03c15](pics/0000.png) NOTE: The development of the Maestro3 CLI is still in progress. Examples below contain demo data. Will be updated.
 
-To get information about the available commands/parameters just run the `m3-cli` as
+To get information about the available commands/parameters just run the `m3` as
 it is displayed below:
 
 Root help contains data about all available commands:
@@ -260,7 +260,7 @@ Use this command to run instance.
 
 Examples:
 1. Describes all available instances for the certain tenant in the specified region
-    m3-cli run-instance -tn <tenant-name> -r <region> -iname <instance-name> -shname <shape-name> -key <key-name> -count <number-of-instances>
+    m3 run-instance -tn <tenant-name> -r <region> -iname <instance-name> -shname <shape-name> -key <key-name> -count <number-of-instances>
 """
 ```
 
@@ -272,7 +272,7 @@ The related commands look like this:
 Related commands:
 
 1. Deletes a schedule from your tenants schedule library:
-        m3-cli delete-schedule -r <region> -tn <tenant> -n <name>
+        m3 delete-schedule -r <region> -tn <tenant> -n <name>
 ```
 
 There are two ways a command can be added to a list of related commands of the other command.

--- a/m3cli/commands_def.json
+++ b/m3cli/commands_def.json
@@ -5037,23 +5037,10 @@
         "region": {
           "alias": "r",
           "api_param_name": "reportZoneType",
-          "help": "The cloud providers or the region or the report family. Allowed values: [AWS, AWS_UNREACHABLE, AZURE, AZURE_NATIVE, ENTERPRISE, PRIVATE, GOOGLE, HARDWARE, MOBILE, SWIFT_STACK, WORKSPACE]",
+          "help": "The cloud providers or the region or the report family. Allowed values: [HARDWARE, AWS, AWS_UNREACHABLE, AZURE, AZURE_NATIVE, GOOGLE, MOBILE, ENTERPRISE, SWIFT_STACK, REPORT_PORTAL, WORKSPACES, AWS_WORKSPACES, AZURE_WORKSPACES, AWS_PAAS, AWS_ATLAS, AZURE_PAAS, GOOGLE_PAAS, PRIVATE_PAAS, PRIVATE]",
           "required": false,
           "validation": {
-            "type": "string",
-            "allowed_values": [
-              "AWS",
-              "AWS_UNREACHABLE",
-              "AZURE",
-              "AZURE_NATIVE",
-              "ENTERPRISE",
-              "PRIVATE",
-              "GOOGLE",
-              "HARDWARE",
-              "MOBILE",
-              "SWIFT_STACK",
-              "WORKSPACE"
-            ]
+            "type": "string"
           },
           "case": "upper"
         },

--- a/m3cli/m3.py
+++ b/m3cli/m3.py
@@ -35,9 +35,11 @@ def init_commands_service():
 def print_version(ctx, value):
     if not value or ctx.resilient_parsing:
         return
-    import pkg_resources  # part of setuptools
-    version = pkg_resources.require('m3')[0].version
-    click.echo(f'Maestro CLI version: {version}')
+
+    from importlib.metadata import version as lib_version
+
+    version_m3 = lib_version('m3-cli')
+    click.echo(f'Maestro CLI version: {version_m3}')
     commands_meta_version = CMD_SERVICE.get_commands_def_version()
     click.echo(f'Commands version: {commands_meta_version}')
     ctx.exit()

--- a/m3cli/utils/utilities.py
+++ b/m3cli/utils/utilities.py
@@ -6,7 +6,6 @@ from getpass import getpass
 from pathlib import Path
 
 import click
-import pkg_resources
 from packaging import version
 
 from m3cli.utils import (ACCESS_KEY, SECRET_KEY, ADDRESS, FOLDERS_SEPARATOR,
@@ -155,8 +154,8 @@ def check_update():
 
 
 def get_current_cli_version():
-    return pkg_resources.require('m3')[0].version
-
+    from importlib.metadata import version as lib_version
+    return lib_version('m3-cli')
 
 def perform_version_check(invoked_command, is_help_invoked,
                           view_type, detailed):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = m3-cli
-version = 3.101.0
+version = 3.101.2
 author = maestrocloudcontrol
 author_email = support@maestrocontrol.cloud
 keywords = Maestro3, Command Line Interface, CLI, CLOUD
@@ -23,7 +23,7 @@ install_requires =
 
 [options.entry_points]
 console_scripts =
-    m3-cli=m3cli.m3:m3
+    m3=m3cli.m3:m3
 
 [options.data_files]
 m3cli = m3cli/commands_def.json, m3cli/m3cli_complete/bash_m3cli_complete.sh, m3cli/m3cli_complete/zsh_m3cli_complete.sh, m3cli/m3cli_complete/m3cli_complete.py, m3cli/m3cli_complete/access_meta.json

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ class CustomInstallCommand(install):
 setup(
     cmdclass={
         'install': CustomInstallCommand
-    },
+    }
 )


### PR DESCRIPTION
[3.101.2] - 2023-12-01
* Update command `m3 mreport --help`:
  * Disable validation for the `region` parameter
  * Update help text for the `region` parameter

[3.101.1] - 2023-11-28
* Fix deprecated `pkg_resources`