### PR TITLE
Updated report command, fixed typos, update -var param in tf commands, updated storage management params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.101.10] - 2024-02-14
+* Update of the `m3 mreport` command: 
+  * Add optional parameter `--include-billing-source`
+
+## [3.101.8] - 2024-01-29
+* Fixed typo in the command `disassociate-ip`
+
+## [3.101.7] - 2024-01-17
+* Fix and update `m3 plantlp` and `m3 applytpl` commands:
+  * The `-var` field can take multiple values, examples are also given
+  * The `-var` field works according to the help and examples provided
+
+## [3.101.6] - 2023-12-14
+* Remove the `resource-group` parameter from command `delete-storage`.
+  * Command no longer requests or requires resource group information.
+
 ## [3.101.5] - 2023-12-07
 * Update `README.md` to fix images not displaying on `PyPI`.
 

--- a/m3cli/commands_def.json
+++ b/m3cli/commands_def.json
@@ -1685,15 +1685,6 @@
           "validation": {
             "type": "string"
           }
-        },
-        "resource-group": {
-          "alias": "rgname",
-          "api_param_name": "resourceGroup",
-          "help": "The resource group name (for Azure)",
-          "required": false,
-          "validation": {
-            "type": "string"
-          }
         }
       },
       "output_configuration": {
@@ -3790,6 +3781,7 @@
           "api_param_name": "variables",
           "help": "The list of parameters with values. \nFormat - key:value for string; key:\"value1, value2, value3\" for list; key1:\"key2=value2\" for object",
           "required": false,
+          "multiple_values": true,
           "validation": {
             "type": "object",
             "properties": {
@@ -3847,6 +3839,7 @@
           "api_param_name": "variables",
           "help": "Parameters with values. \nFormat - key:value for string; key:\"value1, value2, value3\" for list; key1:\"key2=value2\" for object",
           "required": false,
+          "multiple_values": true,
           "validation": {
             "type": "object",
             "properties": {
@@ -5044,6 +5037,15 @@
           },
           "case": "upper"
         },
+        "include-billing-source": {
+          "alias": "ibs",
+          "api_param_name": "includeBillingSource",
+          "help": "A flag. Include billing source for public cloud providers",
+          "required": false,
+          "validation": {
+            "type": "bool"
+          }
+        },
         "tenant-group": {
           "alias": "tg",
           "api_param_name": "tenantGroups",
@@ -5337,7 +5339,7 @@
       "api_action": "ASSOCIATE_IP",
       "alias": "asip",
       "help_file": true,
-      "help": "Associate static ip with instance",
+      "help": "Associate static IP with instance",
       "groups": [
         "instance-management",
         "email-on_run_instance-group"
@@ -5377,11 +5379,11 @@
         ]
       }
     },
-    "diassociate-ip": {
+    "disassociate-ip": {
       "api_action": "DISASSOCIATE_IP",
       "alias": "dsip",
       "help_file": true,
-      "help": "Diassociate static ip with instance",
+      "help": "Disassociate static IP from the instance",
       "groups": [
         "instance-management",
         "email-on_run_instance-group"

--- a/m3cli/commands_help.py
+++ b/m3cli/commands_help.py
@@ -463,16 +463,19 @@ Applies a Terraform template
 Examples:
 
 1. Applies a Terraform template:
-        m3 apply-terraform-template --cloud <cloud_name> --templateName <name> --tenant <tenant_name>   
+        m3 apply-terraform-template --cloud <cloud_name> --template <name> --tenant <tenant_name>   
 
 2. Applies a Terraform template with specific parameters for a string:
-        m3 apply-terraform-template --cloud <cloud_name> --templateName <name> --tenant <tenant_name> --variable <key:value> 
+        m3 apply-terraform-template --cloud <cloud_name> --template <name> --tenant <tenant_name> --variable <key:value> 
 
 3. Applies a Terraform template with specific parameters for a list:
-        m3 apply-terraform-template --cloud <cloud_name> --templateName <name> --tenant <tenant_name> --variable <key:"value1, valueN"> 
+        m3 apply-terraform-template --cloud <cloud_name> --template <name> --tenant <tenant_name> --variable <key:"value1, valueN"> 
 
 4. Applies a Terraform template with specific parameters for an object:
-        m3 apply-terraform-template --cloud <cloud_name> --templateName <name> --tenant <tenant_name> --variable <key1:"key2=value2"> 
+        m3 apply-terraform-template --cloud <cloud_name> --template <name> --tenant <tenant_name> --variable <key1:"key2=value2"> 
+
+5. Applies a Terraform template with multiple values, which can be a combination of strings, lists, and objects:
+        m3 apply-terraform-template --cloud <cloud_name> --template <name> --tenant <tenant_name> --variable <key:value> --variable <key:"value1,valueN"> --variable <key1:"key2=value2">
 """
 
 delete_terraform_template = """
@@ -513,10 +516,13 @@ Examples:
         m3 plan-terraform-template --cloud <cloud_name> --template <name> --tenant <tenant_name> --variable <key:value>
 
 3. Plans a Terraform template with a specific value for a list:
-        m3 plan-terraform-template --cloud <cloud_name> --template <name> --tenant <tenant_name> --variable <key:value1, valueN>
+        m3 plan-terraform-template --cloud <cloud_name> --template <name> --tenant <tenant_name> --variable <key:"value1,valueN">
 
 4. Plans a Terraform template with a specific value for an object:
-        m3 plan-terraform-template --cloud <cloud_name> --template <name> --tenant <tenant_name> --variable <key1:"key2=value2"> 
+        m3 plan-terraform-template --cloud <cloud_name> --template <name> --tenant <tenant_name> --variable <key1:"key2=value2">
+        
+5. Plans a Terraform template with multiple values, which can be a combination of strings, lists, and objects:
+        m3 plan-terraform-template --cloud <cloud_name> --template <name> --tenant <tenant_name> --variable <key:value> --variable <key:"value1,valueN">
 """
 
 total_report = """
@@ -665,18 +671,18 @@ Example:
         m3 associate-ip --tenant <tenant_name> --region <region_name> --static-ip <ip> --instance-id <instance_id>
 """
 
-diassociate_ip = """
-Associate specific static IP with instance:
+disassociate_ip = """
+Disassociate specific static IP from the instance:
 
 Example:
-        m3 diassociate-ip --tenant <tenant_name> --region <region_name> --static-ip <ip>
+        m3 disassociate-ip --tenant <tenant_name> --region <region_name> --static-ip <ip>
 """
 
 multitenant_report = """
 Gets multitenant billing report
     
 Example:
-    m3 multitenant-report --from <dd.mm.yyyy> --to <dd.mm.yyyy> --region <region_zone> --report-type <report_type>
+    m3 multitenant-report --from <dd.mm.yyyy> --to <dd.mm.yyyy> --region <region_zone> --report-type <report_type> --include-billing-source
 """
 
 upload_terraform_template_from_git = """

--- a/m3cli/plugins/apply-terraform-template.py
+++ b/m3cli/plugins/apply-terraform-template.py
@@ -9,24 +9,21 @@ def create_custom_request(request):
     request.parameters['task'] = 'PLAN'
     if request.parameters.get('variables'):
         variables = request.parameters.pop('variables')
-        value = list(variables.values())[0]
-        if ',' in value:
-            type = 'LIST'
-            value = value.replace(' ', '').strip('][').split(',')
-        elif '=' in value:
-            type = 'MAP'
-            temp = value.replace(' ', '').split('=')
-            value = {temp[0]: temp[-1]}
-        else:
-            type = 'STRING'
-        name = list(variables.keys())[0]
-        request.parameters['variables'] = {
-            name: {
+        request.parameters['variables'] = {}
+        for name, value in variables.items():
+            if ',' in value:
+                type = 'LIST'
+                value = value.replace(' ', '').strip('][').split(',')
+            elif '=' in value:
+                type = 'MAP'
+                temp = value.replace(' ', '').split('=')
+                value = {temp[0]: temp[-1]}
+            else:
+                type = 'STRING'
+            request.parameters['variables'][name] = {
                 'type': type,
                 'value': value,
                 'sensitive': True,
                 'name': name
             }
-        }
     return request
-

--- a/m3cli/plugins/delete-storage.py
+++ b/m3cli/plugins/delete-storage.py
@@ -7,12 +7,6 @@ def create_custom_request(request):
     cloud = region.split('-')[0]
 
     additional_params = {}
-    if cloud == 'AZURE':
-        resource_group = params.get('resourceGroup')
-        if not resource_group:
-            raise AssertionError(
-                'Parameter resource-group is required for AZURE cloud')
-        additional_params['resourceGroupName'] = resource_group
     if cloud == 'GCP' or cloud == 'GGL':
         availability_zone = params.get('availabilityZone')
         if not availability_zone:

--- a/m3cli/plugins/plan-terraform-template.py
+++ b/m3cli/plugins/plan-terraform-template.py
@@ -9,23 +9,21 @@ def create_custom_request(request):
     request.parameters['task'] = 'PLAN'
     if request.parameters.get('variables'):
         variables = request.parameters.pop('variables')
-        value = list(variables.values())[0]
-        if ',' in value:
-            type = 'LIST'
-            value = value.replace(' ', '').strip('][').split(',')
-        elif '=' in value:
-            type = 'MAP'
-            temp = value.replace(' ', '').split('=')
-            value = {temp[0]: temp[-1]}
-        else:
-            type = 'STRING'
-        name = list(variables.keys())[0]
-        request.parameters['variables'] = {
-            name: {
+        request.parameters['variables'] = {}
+        for name, value in variables.items():
+            if ',' in value:
+                type = 'LIST'
+                value = value.replace(' ', '').strip('][').split(',')
+            elif '=' in value:
+                type = 'MAP'
+                temp = value.replace(' ', '').split('=')
+                value = {temp[0]: temp[-1]}
+            else:
+                type = 'STRING'
+            request.parameters['variables'][name] = {
                 'type': type,
                 'value': value,
                 'sensitive': True,
                 'name': name
             }
-        }
     return request

--- a/m3cli/services/commands_service.py
+++ b/m3cli/services/commands_service.py
@@ -521,6 +521,12 @@ class CommandsService:
 
         # check parameters using validation attr
         for p_name, p_def in params_def.items():
+            if isinstance(incoming_params.get(p_name), list):
+                if not p_def.get("multiple_values"):
+                    parameters_errors.append(
+                        f'Can specify option only once: {p_name};')
+                incoming_params[p_name] = ",".join(incoming_params.get(p_name))
+
             validation_rules = p_def.get(VALIDATION_KEY)
             if not validation_rules:
                 continue

--- a/m3cli/services/validation_service.py
+++ b/m3cli/services/validation_service.py
@@ -17,6 +17,7 @@ _LOG = get_logger('validation_service')
 
 ROOT_DEFAULT = ''
 LIST_SEPARATOR = ','
+LIST_REGEX_PATTERN = r'''(?:"[^"]+"|[^,\s]+)\s*:\s*(?:"[^"]+"|[^,\s]+)|[^,]+'''
 
 VALIDATION_TYPE = 'type'
 VALIDATION_ALLOWED_VALUES = 'allowed_values'
@@ -404,10 +405,10 @@ class ValidationService:
 
     @staticmethod
     def adapt_object(actual_value):
-        values = actual_value.split(LIST_SEPARATOR)
+        values = re.findall(LIST_REGEX_PATTERN, actual_value)
         object_dict = {}
         for v in values:
-            key, val = v.split(':')
+            key, val = v.replace('"', '').split(':')
             object_dict[key] = val
         return object_dict
 

--- a/m3cli/utils/decorators.py
+++ b/m3cli/utils/decorators.py
@@ -51,21 +51,24 @@ class TextColors:
 
 def __extract_parameters(parameters_list):
     parameters_dict = {}
-    params_values_count = len(parameters_list)
-    index = 0
-    while index < params_values_count:
-        key = parameters_list[index].replace('--', '')
-        # check key duplication
-        if key in parameters_dict.keys():
-            raise AssertionError(f'Can specify option {parameters_list[index]}'
-                                 f' only once')
-        if (index == params_values_count - 1 or
-                parameters_list[index + 1].startswith('-')):
-            parameters_dict[key] = None
-            index += 1
+    param_pfx = '-'
+    full_param_pfx = '--'
+
+    for index in range(len(parameters_list)):
+        if not parameters_list[index].startswith(param_pfx):
+            continue
+        key = parameters_list[index].replace(full_param_pfx, "")
+        if index < len(parameters_list)-1 and not parameters_list[index+1].startswith(param_pfx):
+            val = parameters_list[index+1]
         else:
-            parameters_dict[key] = parameters_list[index + 1]
-            index += 2
+            val = None
+        if key in parameters_dict:
+            if isinstance(parameters_dict[key], list):
+                parameters_dict[key].append(val)
+            else:
+                parameters_dict[key] = [parameters_dict[key], val]
+        else:
+            parameters_dict[key] = val
     return parameters_dict
 
 

--- a/m3cli/utils/utilities.py
+++ b/m3cli/utils/utilities.py
@@ -28,10 +28,7 @@ DEFAULT_API_ADDRESS = 'https://m3api.cloud.epam.com/maestro/api/v3'
 
 
 def inherit_dict(root_dict, child_dict):
-    if root_dict:
-        for root_key, root_value in root_dict.items():
-            if root_key not in child_dict:
-                child_dict[root_key] = root_value
+    child_dict.update({**root_dict, **child_dict})
     return child_dict
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = m3-cli
-version = 3.101.5
+version = 3.101.10
 author = maestrocloudcontrol
 author_email = support@maestrocontrol.cloud
 keywords = Maestro3, Command Line Interface, CLI, CLOUD

--- a/tests/test_plugins/test_delete_storage.py
+++ b/tests/test_plugins/test_delete_storage.py
@@ -6,30 +6,16 @@ class TestDeleteStorage(TestPluginsBase):
 
     def test_delete_storage_success_request(self):
         self.request.parameters = {
-            'region': 'AZURE',
-            'resourceGroup': 'some_group'
+            'region': 'AZURE'
         }
 
         expected_result = {
             'region': 'AZURE',
-            'resourceGroup': 'some_group',
-            'params': {
-                'resourceGroupName': 'some_group'
-            }
+            'params': {}
         }
 
         result = self.execute_create_custom_request()
         self.assertEqual(result.parameters, expected_result)
-
-    def test_delete_storage_resource_group_missed_request(self):
-        self.request.parameters = {
-            'region': 'AZURE'
-        }
-
-        with self.assertRaises(AssertionError) as context:
-            self.execute_create_custom_request()
-        self.assertEqual(str(context.exception), 'Parameter resource-group'
-                                                 ' is required for AZURE cloud')
 
     def test_delete_storage_availability_zone_missed_request(self):
         self.request.parameters = {


### PR DESCRIPTION
## [3.101.10] - 2024-02-14
* Update of the `m3 mreport` command: 
  * Add optional parameter `--include-billing-source`

## [3.101.8] - 2024-01-29
* Fixed typo in the command `disassociate-ip`

## [3.101.7] - 2024-01-17
* Fix and update `m3 plantlp` and `m3 applytpl` commands:
  * The `-var` field can take multiple values, examples are also given
  * The `-var` field works according to the help and examples provided

## [3.101.6] - 2023-12-14
* Remove the `resource-group` parameter from command `delete-storage`.
  * Command no longer requests or requires resource group information.
