### PR TITLE
Updated run instance command, updated script management commands

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
 
 
 default:
-  image: python:3.8
+  image: python:3.10
   timeout: 10m
 
 

--- a/.gitlab/ci/dev.gitlab-ci.yml
+++ b/.gitlab/ci/dev.gitlab-ci.yml
@@ -25,11 +25,11 @@
 .tox-execution-test-script: &tox-execution-test-script
   - python -m site
   - python -m pip install --upgrade pip setuptools wheel
-  - python -m pip install --upgrade virtualenv tox tox-gh-actions
+  - python -m pip install --upgrade virtualenv tox
 
 
 check-installation:
-  image: python:3.8
+  image: python:3.10
   stage: test
   <<: *only-default
   <<: *before-script-default
@@ -51,13 +51,13 @@ lint:
         - ./**
 
 # Uses in sonar.gitlab-ci.yml
-tests-py38:
+tests-py310:
   <<: *only-default
   <<: *before-script-default
   stage: test
   script:
     - *tox-execution-test-script
-    - tox -e py38
+    - tox -e py310
   coverage: '/TOTAL.*\s([.\d]+)%/'
   artifacts:
     paths:

--- a/.gitlab/ci/sonar.gitlab-ci.yml
+++ b/.gitlab/ci/sonar.gitlab-ci.yml
@@ -1,5 +1,5 @@
 tests-for-sonar:
-  extends: tests-py38
+  extends: tests-py310
   allow_failure: true
   artifacts:
     untracked: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.112.4] - 2024-04-08
+* Add `--tag` parameter alias `-tag` to `m3 run-instances` command
+
+## [3.112.3] - 2024-04-05
+* Improve readability of commands: 
+  * m3 upload-script --help, m3 describe-script --help, m3 delete-scripts --help
+
+## [3.112.2] - 2024-04-02
+* Implement fixes related to commands `m3 delete-scripts` and `m3 upload-scripts`:
+  * Change `"maestro-user-identifier"` from `SYSTEM` to `UNKNOWN`
+  * Fix `"api_param_name"` for command `m3 delete-scripts`
+  * Remove `.` from the list of allowed symbols for the `-scname` parameter in 
+  `m3 upload-scripts` command
+  * Enhance help documentation for `m3 upload-scripts` command
+
+## [3.112.1] - 2024-04-01
+* Add `--script` parameter alias `-scname` to `m3 run-instances` command
+
+## [3.112.0] - 2024-03-19
+* Update the `payload` to include `dtoList` and `serviceName` in
+`get_interactivity_option` method for the action `VALIDATE_SERVICE_VARIABLES`
+in the `m3 activate-platform-service` command
+
+## [3.101.11] - 2024-03-15
+* Add command `m3 billing-region-types`
+* Improve the table view for the `m3 billing-region-types --table` command.
+
 ## [3.101.10] - 2024-02-14
 * Update of the `m3 mreport` command: 
   * Add optional parameter `--include-billing-source`

--- a/m3cli/commands_def.json
+++ b/m3cli/commands_def.json
@@ -1360,6 +1360,34 @@
             "min_value": 1,
             "max_value": 200
           }
+        },
+        "script": {
+          "alias": "scname",
+          "api_param_name": "User script",
+          "help": "The name of the script that will be applied",
+          "required": false,
+          "validation": {
+            "type": "string",
+            "regex": "^[\\w\\-._ ]{6,32}$",
+            "regex_error": "Script name must be 6-32 characters long and can include only these characters in lower case: 'a-z', '0-9', .-_ "
+          }
+        },
+        "tag": {
+          "alias": "tag",
+          "api_param_name": "tags",
+          "help": "Tags. Pass several values in the following format: key1:val1,key2:val2,key3:val3",
+          "required": false,
+          "validation": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          }
         }
       },
       "output_configuration": {
@@ -2684,10 +2712,11 @@
     },
     "upload-script": {
       "api_action": "UPLOAD_SCRIPT",
-      "help": "Uploads an init script to tenant's library in Maestro",
+      "help": "Uploads the user script to the specific tenant in Maestro",
       "help_file": true,
       "alias": "upscr",
       "integration_request": true,
+      "integration_response": true,
       "groups": [
         "init-script-management"
       ],
@@ -2701,7 +2730,7 @@
         "source-path": {
           "alias": "spath",
           "api_param_name": "filepath",
-          "help": "The path to the file that will be used as a source of the script",
+          "help": "The path to the script file. The file extension should be either '.sh', '.bat', 'cmd' or '.ps1'",
           "required": true,
           "validation": {
             "type": "file",
@@ -2716,12 +2745,12 @@
         "script": {
           "alias": "scname",
           "api_param_name": "fileName",
-          "help": "The name of the script that will be uploaded",
+          "help": "The name of the script to be uploaded. The file extension(.sh, .cmd, ...) will be taken from 'spath'",
           "required": true,
           "validation": {
             "type": "string",
-            "regex": "^[\\w\\-._ ]{6,32}$",
-            "regex_error": "Script name must be 6-32 characters long and can include only these characters in lower case: 'a-z', '0-9', .-_ "
+            "regex": "^[\\w\\-_ ]{6,32}$",
+            "regex_error": "Script name must be 6-32 characters long and can include only these characters in lower case: 'a-z', '0-9', -_ "
           }
         }
       },
@@ -2740,8 +2769,10 @@
     },
     "delete-scripts": {
       "api_action": "REMOVE_SCRIPT",
-      "help": "Deletes an init script from your library in Maestro",
+      "help": "Deletes the user script from the specific tenant in Maestro",
       "help_file": true,
+      "integration_request": true,
+      "integration_response": true,
       "alias": "delscr",
       "groups": [
         "init-script-management"
@@ -2755,7 +2786,7 @@
         },
         "script": {
           "alias": "scname",
-          "api_param_name": "fileName",
+          "api_param_name": "fileNames",
           "help": "List of the name of the file to be deleted. Pass several values in the following format: value1,value2,value3",
           "required": true,
           "validation": {
@@ -2770,7 +2801,7 @@
     },
     "describe-script": {
       "api_action": "DESCRIBE_SCRIPT",
-      "help": "Describes the script files uploaded to Maestro and available for your tenant",
+      "help": "Describes the script files uploaded to Maestro and available for the specific tenant",
       "help_file": true,
       "alias": "dscript",
       "integration_response": true,
@@ -5059,6 +5090,36 @@
       },
       "output_configuration": {
         "response_table_headers": []
+      }
+    },
+    "billing-region-types": {
+      "api_action": "GET_BILLING_REGION_TYPES",
+      "help": "Gets billing region types",
+      "help_file": true,
+      "alias": "brtypes",
+      "integration_request": false,
+      "integration_response": true,
+      "groups": [
+        "billing-reports",
+        "cli-price-help"
+      ],
+      "parameters": {
+        "all": {
+          "alias": "A",
+          "api_param_name": "all",
+          "help": "A flag. Includes inactive regions.",
+          "required": false,
+          "validation": {
+            "type": "bool"
+          }
+        }
+      },
+      "output_configuration": {
+        "response_table_headers": [
+          "regionType",
+          "regions"
+        ],
+        "nullable": true
       }
     },
     "describe-user-permissions": {

--- a/m3cli/commands_help.py
+++ b/m3cli/commands_help.py
@@ -386,10 +386,10 @@ Creates instances of the specified configuration
 Examples:
 
 1. Runs a single instance:
-        m3 run-instances --image <image_name> ---name <instance_name> --key-name <key_name> --number-of-instances <number> --cloud <cloud> --tenant <tenant_name> --region <region_name> --shape <shape_name>
+        m3 run-instances --image <image_name> ---name <instance_name> --key-name <key_name> --number-of-instances <number> --cloud <cloud> --tenant <tenant_name> --region <region_name> --shape <shape_name> --script <script_name> --tag <tag_key1:val1,tag_key2:val2>
 
 2. Runs several instances from one image:
-        m3 run-instances --image <image_nam> --name <instance_name> --key-name <key_name> --number-of-instances <number> --cloud <cloud> --tenant <tenant_name> --region <region_name> --shape <shape_name>
+        m3 run-instances --image <image_nam> --name <instance_name> --key-name <key_name> --number-of-instances <number> --cloud <cloud> --tenant <tenant_name> --region <region_name> --shape <shape_name> --script <script_name> --tag <tag_key1:val1,tag_key2:val2>
 """
 
 set_tags = """
@@ -683,6 +683,13 @@ Gets multitenant billing report
     
 Example:
     m3 multitenant-report --from <dd.mm.yyyy> --to <dd.mm.yyyy> --region <region_zone> --report-type <report_type> --include-billing-source
+"""
+
+billing_region_types = """
+Gets billing region types
+
+Example:
+    m3 billing-region-types --all
 """
 
 upload_terraform_template_from_git = """

--- a/m3cli/m3.py
+++ b/m3cli/m3.py
@@ -21,8 +21,7 @@ from m3cli.utils.utilities import perform_version_check
 
 sys.excepthook = exception_handler_formatter
 
-CONTEXT_SETTINGS = dict(allow_extra_args=True,
-                        ignore_unknown_options=True)
+CONTEXT_SETTINGS = dict(allow_extra_args=True, ignore_unknown_options=True)
 
 
 @cli_response(no_output=True)

--- a/m3cli/services/commands_service.py
+++ b/m3cli/services/commands_service.py
@@ -2,6 +2,7 @@ import json
 import os
 from copy import copy
 from os.path import expanduser
+from typing import Any
 
 from tabulate import tabulate
 
@@ -395,7 +396,10 @@ class CommandsService:
                 return command_name, cmd_def
         return command_name, None
 
-    def get_secure_params(self, command):
+    def get_secure_params(
+            self,
+            command: str,
+    ) -> list[str | Any]:
         """
         Look for parameters to be encrypted.
 

--- a/m3cli/services/interactive_options_service.py
+++ b/m3cli/services/interactive_options_service.py
@@ -5,12 +5,15 @@ from typing import List, Mapping
 import click
 
 from m3cli.models.interactive_parameter import InteractiveParameter
-from m3cli.services.interactivity import STRING_TYPE, \
-    RemoteValidationService, ParametersProvider, VarfileService, \
-    InteractiveInputService
-from m3cli.utils.interactivity_utils import unavailable_values_detector, \
-    get_interactivity_option
+from m3cli.services.interactivity import (
+    STRING_TYPE, RemoteValidationService, ParametersProvider, VarfileService,
+    InteractiveInputService,
+)
+from m3cli.utils.interactivity_utils import (
+    unavailable_values_detector, get_interactivity_option,
+)
 from m3cli.utils.logger import get_logger
+from m3cli.services.request_service import BaseRequest
 
 _LOG = get_logger('interactive_options_service')
 
@@ -49,14 +52,18 @@ class InteractiveOptionsService:
                 interactive_parameters=interactive_params)
             return self.add_parameters_to_request(request, filled_params)
 
-    def add_parameters_to_request(self, request,
-                                  filled_params: List[InteractiveParameter]):
+    def add_parameters_to_request(
+            self,
+            request,
+            filled_params: List[InteractiveParameter]
+    ):
         request_parameters = request.parameters if request.parameters else {}
         variables_param_name = get_interactivity_option(
             interactive_options=self.interactive_options,
             option_name=OPTION_NAME_ATTRIBUTE)
-        raw_parameters = {param.name: param.to_raw_parameter()
-                          for param in filled_params}
+        raw_parameters = {
+            param.name: param.to_raw_parameter() for param in filled_params
+        }
         request_parameters.update({
             variables_param_name: raw_parameters
         })
@@ -99,20 +106,30 @@ class InteractiveOptionsService:
             raise click.exceptions.Exit()
         return filled_params
 
-    def _run_user_prompts(self, request, interactive_parameters):
+    def _run_user_prompts(
+            self,
+            request: BaseRequest,
+            interactive_parameters: List[InteractiveParameter],
+    ):
         filled_params = []
         while interactive_parameters:
             collected_params = self.input_service.collect_user_input(
-                interactive_parameters=interactive_parameters,
-                request=request)
-            invalid_items = self.remote_validation_service \
-                .validate_parameters(collected_params)
+                interactive_parameters=interactive_parameters, request=request,
+            )
+            invalid_items = self.remote_validation_service.validate_parameters(
+                collected_params,
+                request.parameters.get("serviceName"),
+            )
             if invalid_items:
                 self._show_validation_errors(invalid_items)
-                if self.varfile_service.is_varfile_invalid(invalid_items):
+                if self.varfile_service.is_varfile_invalid(
+                        list(invalid_items.keys())
+                ):
                     raise click.exceptions.Exit()
-            filled_params.extend(param for param in interactive_parameters
-                                 if param not in invalid_items)
+            filled_params.extend(
+                param for param in interactive_parameters
+                if param not in invalid_items
+            )
             interactive_parameters = list(invalid_items.keys())
             for param in interactive_parameters:
                 param.force_prompt()
@@ -140,8 +157,10 @@ class InteractiveOptionsService:
                     'create a template of the variables file.')
             raise click.exceptions.Exit()
 
-    def _show_validation_errors(self,
-                                errors: Mapping[InteractiveParameter, str]):
+    def _show_validation_errors(
+            self,
+            errors: Mapping[InteractiveParameter, str],
+    ):
         click.echo('----------------------------')
         click.echo('Invalid parameters! Errors: ')
         for param, message in errors.items():

--- a/m3cli/services/interactivity/parameters_provider.py
+++ b/m3cli/services/interactivity/parameters_provider.py
@@ -13,8 +13,9 @@ class ParametersProvider:
     def __init__(self, interactive_options):
         self.interactive_options = interactive_options
 
-    def fetch_interactive_parameters(self, request_parameters) \
-            -> List[InteractiveParameter]:
+    def fetch_interactive_parameters(
+            self, request_parameters
+    ) -> List[InteractiveParameter]:
         """
         This function gets parameters for command's request
         which will be asked from user in Interactive mode.

--- a/m3cli/services/request_service.py
+++ b/m3cli/services/request_service.py
@@ -21,6 +21,7 @@ RESPONSE_ENDING_CHARS = b'}]}'
 _LOG = get_logger('request_service')
 
 USER_IDENTIFIER = 'SYSTEM'
+USER_UNKNOWN = 'UNKNOWN'
 CLIENT_IDENTIFIER = "api-server"
 
 POST = 'POST'
@@ -209,7 +210,7 @@ class SdkClient:
                 "Accept": "application/json",
                 "maestro-authentication": signature_resolved,
                 "maestro-request-identifier": CLIENT_IDENTIFIER,
-                "maestro-user-identifier": USER_IDENTIFIER,
+                "maestro-user-identifier": USER_UNKNOWN,
                 "maestro-date": str(date),
                 "maestro-accesskey": access_key,
                 "maestro-sdk-version": get_sdk_version(),

--- a/m3cli/utils/decorators.py
+++ b/m3cli/utils/decorators.py
@@ -136,12 +136,14 @@ def dynamic_dispatcher(func):
                   '--path') in ctx.args:
                 try:
                     access = get_non_interactive_access(
-                        *check_args_for_non_interactive_access(ctx))
+                        *check_args_for_non_interactive_access(ctx)
+                    )
                     click.echo(access)
                 except AssertionError as e:
                     action = f'The command \"{ctx.args[0]}\" failed'
-                    response = __prettify_error(action=action,
-                                                error=e)
+                    response = __prettify_error(
+                        action=action, error=e,
+                    )
                     click.echo(response, err=True)
                     raise e
             else:
@@ -192,8 +194,10 @@ def dynamic_dispatcher(func):
             command = 'health-check'
             parameters = {}
 
-        response = func(*args, command=command, parameters=parameters,
-                        view_type=view_type, detailed=detailed, raw_response=raw_response)
+        response = func(
+            *args, command=command, parameters=parameters, view_type=view_type,
+            detailed=detailed, raw_response=raw_response
+        )
         return response
 
     return wrapper

--- a/m3cli/utils/utilities.py
+++ b/m3cli/utils/utilities.py
@@ -47,19 +47,27 @@ def _set_credentials_interactively(credentials_path):
                                 m3sdk_secret_key, m3sdk_api_address)
 
 
-def _set_credentials_by_params(credentials_path, access_key: str = None,
-                               secret_key: str = None,
-                               api_address: str = None):
+def _set_credentials_by_params(
+        credentials_path,
+        access_key: str = None,
+        secret_key: str = None,
+        api_address: str = None,
+):
     api_address = DEFAULT_API_ADDRESS if not api_address else api_address
     os.environ[ACCESS_KEY] = access_key
     os.environ[SECRET_KEY] = secret_key
     os.environ[ADDRESS] = api_address
-    __write_credentials_to_file(credentials_path, access_key, secret_key,
-                                api_address)
+    __write_credentials_to_file(
+        credentials_path, access_key, secret_key, api_address,
+    )
 
 
-def __write_credentials_to_file(credentials_path: str, access_key: str,
-                                secret_key: str, api_address: str):
+def __write_credentials_to_file(
+        credentials_path: str,
+        access_key: str,
+        secret_key: str,
+        api_address: str,
+):
     data = {}
     if os.path.exists(credentials_path):
         with open(credentials_path, 'r') as file:
@@ -67,8 +75,8 @@ def __write_credentials_to_file(credentials_path: str, access_key: str,
                 data = json.load(file)
             except json.decoder.JSONDecodeError:
                 raise SyntaxError(
-                    f'{credentials_path} contains invalid JSON')
-
+                    f'{credentials_path} contains invalid JSON'
+                )
     with open(credentials_path, 'w') as file:
         data.update({ACCESS_KEY: access_key,
                      SECRET_KEY: secret_key,
@@ -86,16 +94,21 @@ def _get_credentials_file_path():
     return creds_path + FOLDERS_SEPARATOR + CREDENTIALS_FILE
 
 
-def get_non_interactive_access(access_key: str, secret_key: str,
-                               api_address=None, path=None):
+def get_non_interactive_access(
+        access_key: str,
+        secret_key: str,
+        api_address=None,
+        path=None,
+) -> str:
     if path:
         creds_filepath = Path(path)
         creds_filepath.mkdir(parents=True, exist_ok=True)
         creds_filepath = creds_filepath / CREDENTIALS_FILE
     else:
         creds_filepath = _get_credentials_file_path()
-    _set_credentials_by_params(creds_filepath, access_key, secret_key,
-                               api_address)
+    _set_credentials_by_params(
+        creds_filepath, access_key, secret_key, api_address,
+    )
     return f'Credentials have been successfully saved in: \n{creds_filepath}'
 
 
@@ -153,6 +166,7 @@ def check_update():
 def get_current_cli_version():
     from importlib.metadata import version as lib_version
     return lib_version('m3-cli')
+
 
 def perform_version_check(invoked_command, is_help_invoked,
                           view_type, detailed):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = m3-cli
-version = 3.101.10
+version = 3.112.4
 author = maestrocloudcontrol
 author_email = support@maestrocontrol.cloud
 keywords = Maestro3, Command Line Interface, CLI, CLOUD

--- a/tests/test_services/test_interactivity/test_remote_validation_service.py
+++ b/tests/test_services/test_interactivity/test_remote_validation_service.py
@@ -32,23 +32,26 @@ class TestRemoteValidationServiceValidateParameters(
         parameter3 = InteractiveParameter({'name': 'param3',
                                            'type': 'LIST'})
         parameters = [parameter1, parameter3]
-        result = self.service.validate_parameters(parameters)
+        result = self.service.validate_parameters(parameters, "TEST")
         self.request_remote_validation_mock.assert_has_calls(
             [call(api_action='API_ACTION',
-                  parameters=[
-                      {'name': 'param1',
-                       'value': None,
-                       'defaultValue': None,
-                       'type': 'LIST',
-                       'sensitive': False
-                       },
-                      {'name': 'param3',
-                       'value': None,
-                       'defaultValue': None,
-                       'type': 'LIST',
-                       'sensitive': False
-                       }
-                  ])
+                  parameters={
+                      'dtoList': [
+                          {'name': 'param1',
+                           'value': None,
+                           'defaultValue': None,
+                           'type': 'LIST',
+                           'sensitive': False
+                           },
+                          {'name': 'param3',
+                           'value': None,
+                           'defaultValue': None,
+                           'type': 'LIST',
+                           'sensitive': False
+                           }
+                      ],
+                      'serviceName': 'TEST'
+                  })
              ]
         )
         self.assertEqual(result, {
@@ -95,5 +98,5 @@ class TestRemoteValidationServiceRequestRemoveValidation(
         request = execute_kwargs['request']
         self.assertEqual(request.command, 'validate_parameters')
         self.assertEqual(request.api_action, self.api_action)
-        self.assertEqual(request.parameters, list(self.parameters))
+        self.assertEqual(request.parameters, self.parameters)
         self.assertEqual(request.method, 'POST')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,lint
+envlist = py310,lint
 skipsdist = True
 isolated_build = True
 
@@ -17,7 +17,7 @@ deps =
     -rrequirements-dev.txt
 
 
-[testenv:py38]
+[testenv:py310]
 commands =
     pytest -v {posargs}
 


### PR DESCRIPTION
v## [3.112.4] - 2024-04-08
* Add `--tag` parameter alias `-tag` to `m3 run-instances` command

## [3.112.3] - 2024-04-05
* Improve readability of commands: 
  * m3 upload-script --help, m3 describe-script --help, m3 delete-scripts --help

## [3.112.2] - 2024-04-02
* Implement fixes related to commands `m3 delete-scripts` and `m3 upload-scripts`:
  * Change `"maestro-user-identifier"` from `SYSTEM` to `UNKNOWN`
  * Fix `"api_param_name"` for command `m3 delete-scripts`
  * Remove `.` from the list of allowed symbols for the `-scname` parameter in 
  `m3 upload-scripts` command
  * Enhance help documentation for `m3 upload-scripts` command

## [3.112.1] - 2024-04-01
* Add `--script` parameter alias `-scname` to `m3 run-instances` command

## [3.112.0] - 2024-03-19
* Update the `payload` to include `dtoList` and `serviceName` in
`get_interactivity_option` method for the action `VALIDATE_SERVICE_VARIABLES`
in the `m3 activate-platform-service` command

## [3.101.11] - 2024-03-15
* Add command `m3 billing-region-types`
* Improve the table view for the `m3 billing-region-types --table` command.
